### PR TITLE
Include log writes as db writes

### DIFF
--- a/defaults.properties
+++ b/defaults.properties
@@ -8,3 +8,4 @@ gitcmd='git'
 curlcmd='curl'
 groupedthreshold=4
 singlestepthreshold=2
+includelogs=1

--- a/jmeter_config.properties.dist
+++ b/jmeter_config.properties.dist
@@ -8,7 +8,7 @@
 jmeter_path=/opt/apache-jmeter-2.9
 
 
-## Comparison thresholds #######################
+## Results #######################
 
 # You can use these vars to specify what difference between runs
 # can be considered an increase or a decrease and what can
@@ -33,3 +33,7 @@ jmeter_path=/opt/apache-jmeter-2.9
 #
 # thresholds='{"bystep":{"dbreads":2,"dbwrites":2,"memoryused":2,"filesincluded":1,"serverload":10,"sessionsize":2,"timeused":5},"total":{"dbreads":2,"dbwrites":2,"memoryused":2,"filesincluded":1,"serverload":10,"sessionsize":2,"timeused":5}}'
 #
+# Include logs table writes as db writes, this is enabled by default.
+# Set includelogs="" in case you don't want to include them.
+#
+# includelogs=1

--- a/recorder.bsf
+++ b/recorder.bsf
@@ -19,11 +19,21 @@ MoodleResult(JMeterContext ctx) {
         dbreads = mdbreads.group(1);
     }
 
-    String dbwrites = "0";
+    String dbwritesstr = "0";
     Pattern pdbwrites = Pattern.compile(".*?DB reads/writes: \\d+/(\\d+).*", Pattern.UNIX_LINES | Pattern.DOTALL);
     Matcher mdbwrites = pdbwrites.matcher(html);
     if (mdbwrites.matches()) {
-        dbwrites = mdbwrites.group(1);
+        dbwritesstr = mdbwrites.group(1);
+    }
+    Integer dbwrites = Integer.parseInt(dbwritesstr);
+
+    // Adding logs if required.
+    if (props.get("includelogs") != null) {
+        Pattern plogwrites = Pattern.compile(".*?Log DB writes (\\d+).*", Pattern.UNIX_LINES | Pattern.DOTALL);
+        Matcher mlogwrites = plogwrites.matcher(html);
+        if (mlogwrites.matches()) {
+            dbwrites = dbwrites + Integer.parseInt(mlogwrites.group(1));
+        }
     }
 
     String memoryused = "0";
@@ -87,7 +97,7 @@ MoodleResult(JMeterContext ctx) {
         str += StringUtils.rightPad(username, 10) + " | ";
         str += StringUtils.rightPad(name, 30) + " | ";
         str += StringUtils.rightPad(dbreads, 4) + " | ";
-        str += StringUtils.rightPad(dbwrites, 4) + " | ";
+        str += StringUtils.rightPad(Integer.toString(dbwrites), 4) + " | ";
         str += StringUtils.rightPad(memoryused, 8) + " | ";
         str += StringUtils.rightPad(filesincluded, 6) + " | ";
         str += StringUtils.rightPad(serverload, 6) + " | ";
@@ -100,7 +110,7 @@ MoodleResult(JMeterContext ctx) {
        php += "    'thread'=>"+thread+",\n";        // Int
        php += "    'starttime'=>"+starttime+",\n";      // Long
        php += "    'dbreads'=>"+Integer.parseInt(dbreads)+",\n";    // String => Int
-       php += "    'dbwrites'=>"+Integer.parseInt(dbwrites)+",\n";  // String => Int
+       php += "    'dbwrites'=>"+dbwrites+",\n";
        php += "    'memoryused'=>'"+memoryused+"',\n";
        php += "    'filesincluded'=>'"+filesincluded+"',\n";
        php += "    'serverload'=>'"+serverload+"',\n";

--- a/test_runner.sh
+++ b/test_runner.sh
@@ -33,6 +33,7 @@
 . ./lib/lib.sh
 
 # Load properties.
+load_properties "defaults.properties"
 load_properties "jmeter_config.properties"
 
 # Load the generated files locations (when jmeter is running in the same server than the web server).
@@ -139,11 +140,14 @@ datestring=`date '+%Y%m%d%H%M'`
 logfile="logs/jmeter.$datestring.log"
 runoutput="runs_outputs/$datestring.output"
 
+# Include logs string.
+includelogsstr="-Jincludelogs=$includelogs"
+
 # Run it baby! (without GUI).
 echo "#######################################################################"
 echo "Test running... (time for a coffee?)"
 jmeterbin=$jmeter_path/bin/jmeter
-$jmeterbin -n -j "$logfile" -t "$testplanfile" -Jusersfile="$testusersfile" -Jgroup="$group" -Jdesc="$description" -Jsiteversion="$siteversion" -Jsitebranch="$sitebranch" -Jsitecommit="$sitecommit" $users $loops $rampup $throughput > $runoutput
+$jmeterbin -n -j "$logfile" -t "$testplanfile" -Jusersfile="$testusersfile" -Jgroup="$group" -Jdesc="$description" -Jsiteversion="$siteversion" -Jsitebranch="$sitebranch" -Jsitecommit="$sitecommit" $includelogsstr $users $loops $rampup $throughput > $runoutput
 jmeterexitcode=$?
 if [ "$jmeterexitcode" -ne "0" ]; then
     echo "Error: Jmeter can not run, ensure that:"


### PR DESCRIPTION
Log table writes are not counted as db writes, the benefits of this are:
- It is easier to detect any regression in dbwrites (one of the most important factors) as a difference will be that big that will always be outside the confidence interval (the defined threshold)
- A new log entry into the database is not a regression, is like adding a new feature.

On the other hand:
- Being strict, a log write is a db log and we should count them as we count any db write

I'm adding a new setting to manage this. 

Once we release 2.6 and the next minor 2.5 we must update the base commits as with this kind of changes previous runs will not be comparable.
