### PR TITLE
Issue #51 - Adding seconds to the jmeter log file generated

### DIFF
--- a/test_runner.sh
+++ b/test_runner.sh
@@ -136,7 +136,7 @@ else
 fi
 
 # Uses the test plan specified in the CLI call.
-datestring=`date '+%Y%m%d%H%M'`
+datestring=`date '+%Y%m%d%H%M%S'`
 logfile="logs/jmeter.$datestring.log"
 runoutput="runs_outputs/$datestring.output"
 


### PR DESCRIPTION
Too risky, this is not a perfect solution
but the previous code may perfectly provoke
collisions if test_runner.sh runs are
being cancelled.