### PR TITLE
Fix non well-formed numeric value with PHP7 issues

### DIFF
--- a/recorder.bsf
+++ b/recorder.bsf
@@ -65,7 +65,7 @@ MoodleResult(JMeterContext ctx) {
     }
 
     String sessionsize = "0";
-    Pattern psessionsize = Pattern.compile(".*?Session[^:]*: (\\d+(\\.\\d+)?[A-Z]{2}).*", Pattern.UNIX_LINES | Pattern.DOTALL);
+    Pattern psessionsize = Pattern.compile(".*?Session[^:]*: (\\d+(\\.\\d+)?).*", Pattern.UNIX_LINES | Pattern.DOTALL);
     Matcher msessionsize = psessionsize.matcher(html);
     if (msessionsize.matches()) {
         sessionsize = msessionsize.group(1);
@@ -115,6 +115,12 @@ MoodleResult(JMeterContext ctx) {
     }
 
     toPHP() {
+
+       if (sessionsize.indexOf(".") == -1) {
+           // bytes to KB.
+           sessionsize = "0." + sessionsize;
+       }
+
        String php = "$results["+thread+"][] = array(\n";
        php += "    'thread'=>"+thread+",\n";        // Int
        php += "    'starttime'=>"+starttime+",\n";      // Long

--- a/webapp/classes/properties_reader.php
+++ b/webapp/classes/properties_reader.php
@@ -43,7 +43,7 @@ class properties_reader {
                     foreach ($vars as $var) {
                         $return = self::extract_properties_file_value($var, $line);
                         if ($return && empty($propertiesvalues[$var])) {
-                            $propertiesvalues[$var] = $return;
+                            $propertiesvalues[$var] = preg_replace('/[^0-9\.]/', '', $return);
                         }
                     }
                 }

--- a/webapp/classes/test_plan_runs.php
+++ b/webapp/classes/test_plan_runs.php
@@ -170,6 +170,12 @@ class test_plan_run {
                         $this->rawtotals[$var][$stepname] = array();
                     }
 
+                    if ($var === 'sessionsize') {
+                        // Strip out the KB, MB... part (it is language dependant, so better to strip out
+                        // everything that is not a number of \.).
+                        $threadstep[$var] = preg_replace('/[^0-9\.]/', '', $threadstep[$var]);
+                    }
+
                     $this->totalsums[$var][$stepname] = $this->totalsums[$var][$stepname] + $threadstep[$var];
                     $this->rawtotals[$var][$stepname][] = $threadstep[$var];
                 }


### PR DESCRIPTION
Different fixes:
- Session size is less than 1KB in some pages now (congrats moodle devs) the java recorder didn't parse correctly these values in bytes
- The change in webapp/classes/properties_reader.php cleans a trailing space

IMPORTANT NOTE FOR THE INTEGRATOR:
webapp/classes/test_plan_runs.php changes should be enough as long as we don't compare results recorded before this fix and after, in normal circumstances we only test latest weekly against current integration, so Friday after the release seems the best time to integrate this. We could only avoid the compare previous results thing by updating all previously generated files which would require time. Any opinion?