### PR TITLE
Improve recorder sessionsize detection

### DIFF
--- a/recorder.bsf
+++ b/recorder.bsf
@@ -65,7 +65,7 @@ MoodleResult(JMeterContext ctx) {
     }
 
     String sessionsize = "0";
-    Pattern psessionsize = Pattern.compile(".*?Session[^:]*: (\\d+(\\.\\d+)?).*", Pattern.UNIX_LINES | Pattern.DOTALL);
+    Pattern psessionsize = Pattern.compile(".*?Session[^:]*: (\\d+(\\.\\d+)? ?[a-zA-Z]*).*", Pattern.UNIX_LINES | Pattern.DOTALL);
     Matcher msessionsize = psessionsize.matcher(html);
     if (msessionsize.matches()) {
         sessionsize = msessionsize.group(1);
@@ -116,9 +116,13 @@ MoodleResult(JMeterContext ctx) {
 
     toPHP() {
 
-       if (sessionsize.indexOf(".") == -1) {
-           // bytes to KB.
-           sessionsize = "0." + sessionsize;
+       int bytesPos = sessionsize.indexOf(" bytes");
+       int kbsPos = sessionsize.indexOf("KB");
+       // Convert the size to KB and strip out the measure.
+       if (bytesPos != -1) {
+           sessionsize = "0." + sessionsize.substring(0, bytesPos);
+       } else if (kbsPos != -1) {
+           sessionsize = sessionsize.substring(0, kbsPos);
        }
 
        String php = "$results["+thread+"][] = array(\n";


### PR DESCRIPTION
Previous code didn't consider that KBs are rounded to 0
and returned as an int value, not float so something like
12KB is returned from Moodle instead of 12.0KB.