### PR TITLE
Failing due to invalid comparison from JSON

### DIFF
--- a/webapp/classes/properties_reader.php
+++ b/webapp/classes/properties_reader.php
@@ -43,7 +43,7 @@ class properties_reader {
                     foreach ($vars as $var) {
                         $return = self::extract_properties_file_value($var, $line);
                         if ($return && empty($propertiesvalues[$var])) {
-                            $propertiesvalues[$var] = preg_replace('/[^0-9\.]/', '', $return);
+                            $propertiesvalues[$var] = trim($return);
                         }
                     }
                 }


### PR DESCRIPTION
#58/#59 included a fix to remove non-numeric values (https://github.com/moodlehq/moodle-performance-comparison/pull/59/commits/a902b3276bd94397b14d5cbda8c27e4b0a4d4328)

However, in some situations, the value is fully-formed JSON and is now being altered in a breaking way:

```
{"bystep":{"dbreads":1,"dbwrites":2000,"dbquerytime":2000,"memoryused":3,"filesincluded":1,"serverload":2000,"sessionsize":2,"timeused":40},"total":{"dbreads":1,"dbwrites":2000,"dbquerytime":200,"memoryused":3,"filesincluded":1,"serverload":20000,"sessionsize":2,"timeused":6}}
```

becomes:
```
12000200031200024012000200312000026
```