### PR TITLE
Fix the "timeused" recorder/scrapper.

### DIFF
--- a/recorder.bsf
+++ b/recorder.bsf
@@ -72,7 +72,7 @@ MoodleResult(JMeterContext ctx) {
     }
 
     String timeused = "0";
-    Pattern ptimeused = Pattern.compile(".*?\"timeused\">(\\d+(\\.\\d+)?) secs.*", Pattern.UNIX_LINES | Pattern.DOTALL);
+    Pattern ptimeused = Pattern.compile(".*?\"timeused[^\"]*\">(\\d+(\\.\\d+)?) secs.*", Pattern.UNIX_LINES | Pattern.DOTALL);
     Matcher mtimeused = ptimeused.matcher(html);
     if (mtimeused.matches()) {
         timeused = mtimeused.group(1);


### PR DESCRIPTION
Right now it was reporting 0 all the time. That's because at some
point some BS classes were added to it:

lib/moodlelib.php
`<li class="timeused col-sm-4">'.$info['realtime'].' secs</li>`

and the recorder was not matching anymore. This simple change allows
the recorder to find it properly, in a BC way (old sites).

Not that the "timeused" indication is the most important at all, because
can fli-flop a lot... but better we get it back.