### PR TITLE
Add support for normalized calculations

### DIFF
--- a/details.php
+++ b/details.php
@@ -22,6 +22,7 @@ $width = '300';
 $height = '150';
 $organiseby = 'filesincluded';
 $mostcommononly = false;
+$normalize = false;
 if (!empty($_GET['before']) && array_key_exists($_GET['before'], $runs)) {
     $before = $_GET['before'];
 }
@@ -40,21 +41,28 @@ if (!empty($_GET['o']) && preg_match('/^[a-z]+$/', $_GET['o'])) {
 if (!empty($_GET['x']) && preg_match('/^(0|1|true|false)$/', $_GET['x'])) {
     $mostcommononly = (bool)$_GET['x'];
 }
+if (!empty($_GET['n']) && preg_match('/^(0|1|true|false)$/', $_GET['n'])) {
+    $normalize = (bool)$_GET['n'];
+}
 
 $pages = array();
 if ($before && $after) {
-    $pages = build_pages_array($runs, $before, $after);
+    $pages = build_pages_array($runs, $before, $after, $normalize);
 }
 
 echo "<html>";
 echo "<head>";
-echo '<script type="text/javascript" src="http://yui.yahooapis.com/combo?3.3.0/build/yui/yui-min.js&3.3.0/build/oop/oop-min.js&3.3.0/build/event-custom/event-custom-base-min.js&3.3.0/build/event/event-base-min.js&3.3.0/build/dom/dom-base-min.js&3.3.0/build/dom/selector-native-min.js&3.3.0/build/dom/selector-css2-min.js&3.3.0/build/node/node-base-min.js&3.3.0/build/event/event-base-ie-min.js&3.3.0/build/event-custom/event-custom-complex-min.js&3.3.0/build/event/event-synthetic-min.js&3.3.0/build/event/event-hover-min.js&3.3.0/build/dom/dom-style-min.js&3.3.0/build/dom/dom-style-ie-min.js&3.3.0/build/node/node-style-min.js"></script>';
+$httpyuilib = 'http://yui.yahooapis.com';
+if (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off') {
+    $httpyuilib = 'https://yui-s.yahooapis.com';
+}
+echo '<script type="text/javascript" src="' . $httpyuilib . '/combo?3.3.0/build/yui/yui-min.js&3.3.0/build/oop/oop-min.js&3.3.0/build/event-custom/event-custom-base-min.js&3.3.0/build/event/event-base-min.js&3.3.0/build/dom/dom-base-min.js&3.3.0/build/dom/selector-native-min.js&3.3.0/build/dom/selector-css2-min.js&3.3.0/build/node/node-base-min.js&3.3.0/build/event/event-base-ie-min.js&3.3.0/build/event-custom/event-custom-complex-min.js&3.3.0/build/event/event-synthetic-min.js&3.3.0/build/event/event-hover-min.js&3.3.0/build/dom/dom-style-min.js&3.3.0/build/dom/dom-style-ie-min.js&3.3.0/build/node/node-style-min.js"></script>';
 echo '<link rel="stylesheet" type="text/css" href="webapp/jmeter.css" />';
 echo "<script type='text/javascript' src='webapp/jmeter.js'></script>";
 echo "</head>";
 echo "<body>";
 
-display_run_selector($runs, $before, $after, array('w' => $width, 'h' => $height), $organiseby, $mostcommononly);
+display_run_selector($runs, $before, $after, array('w' => $width, 'h' => $height), $organiseby, $mostcommononly, $normalize);
 
 if ($before && $after) {
     $count = 0;
@@ -87,8 +95,8 @@ if ($before && $after) {
             if (!property_exists($page['before'], $PROPERTY)) {
                 continue;
             }
-            $graphfile = produce_page_graph($PROPERTY, $before, $page['before'], $after, $page['after'], $width, $height, array('x' => $mostcommononly));
-            echo "<a href='webapp/graph.php?before=$before&after=$after&property=$PROPERTY&page=$key' class='largegraph'>";
+            $graphfile = produce_page_graph($PROPERTY, $before, $page['before'], $after, $page['after'], $width, $height, array('x' => $mostcommononly, 'n' => $normalize));
+            echo "<a href='webapp/graph.php?before=$before&after=$after&property=$PROPERTY&page=$key&n=$normalize' class='largegraph'>";
             echo "<img src='./cache/".$graphfile."' alt='$PROPERTY' style='width:{$width}px;height:{$height}px;' />";
             echo "</a>";
         }

--- a/detect_big_differences.php
+++ b/detect_big_differences.php
@@ -15,9 +15,20 @@
  */
 
 include(__DIR__ . '/webapp/inc.php');
+include(__DIR__ . '/webapp/lib.php');
+
+$normalize = false;
 
 // Removing the script name.
 array_shift($argv);
+
+// Look for the --outliers flag in order to normalize.
+foreach ($argv as $key => $arg) {
+    if ($arg == '--outliers' || substr($arg, 0, 9) == '--normali') {
+        $normalize = true;
+        unset($argv[$key]);
+    }
+}
 
 if (empty($argv)) {
     echo 'Error: You need to specify the runs filenames without their .php sufix.' . PHP_EOL;
@@ -33,7 +44,7 @@ if (count($argv) == 1) {
 $timestamps = $argv;
 
 $report = new report();
-if (!$report->parse_runs($timestamps)) {
+if (!$report->parse_runs($timestamps, $normalize)) {
     echo 'Error: The selected runs are not comparable.' . PHP_EOL;
     foreach ($report->get_errors() as $var => $error) {
         echo $var . ': ' . $error . PHP_EOL;
@@ -52,10 +63,15 @@ $branches = $report->get_big_differences();
 $exitcode = 0;
 if ($branches) {
     foreach ($branches as $branchnames => $changes) {
+        if (!empty($changes)) {
+            echo "$branchnames" . PHP_EOL;
+        }
         foreach ($changes as $state => $data) {
             foreach ($data as $var => $steps) {
                 foreach ($steps as $stepname => $info) {
-                    echo "$branchnames - $state: $var - $stepname -> $info" . PHP_EOL;
+                    $normalizestr = $normalize ? '(Normalized) ' : '';
+                    echo $normalizestr;
+                    echo "- $state: $var - $stepname -> $info" . PHP_EOL;
                 }
             }
         }

--- a/index.php
+++ b/index.php
@@ -1,16 +1,22 @@
 <?php
 
 include(__DIR__ . '/webapp/inc.php');
+require_once(__DIR__ . '/webapp/lib.php');
 
 $report = new report();
 
 if (!empty($_GET['timestamps'])) {
 
+    $normalize = false;
+    if (!empty($_GET['n']) && preg_match('/^(0|1|true|false)$/', $_GET['n'])) {
+        $normalize = (bool)$_GET['n'];
+    }
+
     // Create the report.
-    $report->make($_GET['timestamps']);
+    $report->make($_GET['timestamps'], $normalize);
 
 }
 
 // Render it.
 $renderer = new report_renderer($report);
-$renderer->render();
+$renderer->render($normalize);

--- a/webapp/classes/report.php
+++ b/webapp/classes/report.php
@@ -93,9 +93,10 @@ class report {
      * Gets the runs data
      *
      * @param array $timestamps We will get the runs files from their timestamp (is part of the name).
+     * @param bool $normalize We want to normalize clear outliers.
      * @return bool Whether runs are comparable or not.
      */
-    public function parse_runs(array $timestamps) {
+    public function parse_runs(array $timestamps, bool $normalize = false) {
 
         foreach ($timestamps as $timestamp) {
 
@@ -104,7 +105,7 @@ class report {
             }
 
             // Creating the run object and parsing it.
-            $run = new test_plan_run($timestamp);
+            $run = new test_plan_run($timestamp, $normalize);
             $run->parse_results();
             $this->runs[] = $run;
         }
@@ -121,15 +122,16 @@ class report {
      * Generates the report
      *
      * @param array $timestamps We will get the runs files from their timestamp (is part of the name).
+     * @param bool $normalize We want to normalize clear outliers.
      * @return bool False if problems were found.
      */
-    public function make(array $timestamps) {
+    public function make(array $timestamps, $normalize = false) {
 
         // They come from the form in the opposite order.
         krsort($timestamps);
 
         // Gets the runs data and checks that it is comparable.
-        if (!$this->parse_runs($timestamps)) {
+        if (!$this->parse_runs($timestamps, $normalize)) {
             // No need to parse anything if it is not comparable.
             return false;
         }
@@ -293,6 +295,7 @@ class report {
             $varaggregates = array_fill_keys($run->get_run_var_names(), 0);
 
             $runtotals = $run->get_run_dataset(false, 'totalsums');
+
             foreach ($runtotals as $var => $steps) {
 
                 $branchnames = 'between ' . $baserun->get_run_info_string() . ' and ' . $run->get_run_info_string();
@@ -412,7 +415,7 @@ class report {
         }
 
         if (($difference - $threshold) > 100) {
-            return array('increment', $change . '% worst');
+            return array('increment', $change . '% worse');
         } else if (($difference + $threshold) < 100) {
             return array('decrease', $change . '% better');
         }

--- a/webapp/classes/report_renderer.php
+++ b/webapp/classes/report_renderer.php
@@ -27,9 +27,11 @@ class report_renderer {
     /**
      * Outputs wrapper.
      *
+     * @param bool $normalize are we calculating normalized results
+     *
      * @return void
      */
-    public function render() {
+    public function render($normalize = false) {
         echo $this->output_head();
 
         echo $this->output_form();
@@ -40,10 +42,9 @@ class report_renderer {
         // Link to Sam's tool with detailed data (just the first 2 runs).
         if (!empty($_GET['timestamps']) && count($_GET['timestamps']) >= 2) {
             $urlparams = 'before=' . $_GET['timestamps'][1] . '&after=' . $_GET['timestamps'][0];
+            $urlparams .= $normalize ? '&n=1' : '';
             echo '<div class="switchtool"><a href="details.php?' . $urlparams . '" target="_blank">See numeric info</a></div>';
         }
-
-
     }
 
     /**
@@ -149,6 +150,14 @@ class report_renderer {
         }
 
         $runsselect .= '<br/><br/><input type="submit" value="View comparison"/>';
+        // Allow to select normalize here.
+        $normalize = false;
+        if (!empty($_GET['n']) && preg_match('/^(0|1|true|false)$/', $_GET['n'])) {
+            $normalize = (bool)$_GET['n'];
+        }
+        $checked = $normalize ? ' checked' : '';
+        $runsselect .= '&nbsp;<input type="checkbox" id="normalize" name="n" value="1"'. $checked . '>' .
+            '<label for="normalize">Normalize outlier samples</label>';
         $output .= $this->create_table('Select runs', array($runsselect), 1);
         $output .= '</form>';
 

--- a/webapp/graph.php
+++ b/webapp/graph.php
@@ -20,6 +20,7 @@ $before = null;
 $after = null;
 $width = '800';
 $height = '600';
+$normalize = false;
 if (!empty($_GET['before']) && array_key_exists($_GET['before'], $runs)) {
     $before = $_GET['before'];
     $beforekey = array_search($before, $runs);
@@ -37,10 +38,13 @@ if (!empty($_GET['w']) && preg_match('/^\d+$/', $_GET['w'])) {
 if (!empty($_GET['h']) && preg_match('/^\d+$/', $_GET['h'])) {
     $height = (int)$_GET['h'];
 }
+if (!empty($_GET['n']) && preg_match('/^(0|1|true|false)$/', $_GET['n'])) {
+    $normalize = (bool)$_GET['n'];
+}
 
 $pages = array();
 if ($before && $after) {
-    $pages = build_pages_array($runs, $before, $after);
+    $pages = build_pages_array($runs, $before, $after, $normalize);
 }
 
 if (isset($_GET['page']) && array_key_exists($_GET['page'], $pages)) {
@@ -48,5 +52,8 @@ if (isset($_GET['page']) && array_key_exists($_GET['page'], $pages)) {
 }
 
 echo "<html><head></head><body style='margin:0;padding:0;text-align:center;'>";
-echo "<img src='./cache/".produce_page_graph($property, $beforekey, $page['before'], $afterkey, $page['after'], $width, $height)."' alt='$property' style='width:{$width}px;height:{$height}px;' />";
+echo "<img src='../cache/" .
+    produce_page_graph($property, $beforekey, $page['before'], $afterkey, $page['after'],
+        $width, $height, array('n' => $normalize)) .
+    "' alt='$property' style='width:{$width}px;height:{$height}px;' />";
 echo "</body></html>";

--- a/webapp/jmeter.css
+++ b/webapp/jmeter.css
@@ -44,5 +44,5 @@ a img {border:0;}
 
 #lightbox {width:100%;height:100%;position:fixed;top:0;left:0;background-color:#000;opacity:0.7;z-index:10000;}
 #overlay {position:fixed;top:0;left:0;width:100%;height:100%;z-index:20000;}
-#overlay iframe {width:60%;height:600px;margin:100px 20% 0;border-color:#FFF;border-style:solid;background-color:#FFF;}
-#overlay .close {background-color:#FFF;text-align:right;color:#aaa;font-weight:bold;text-transform:uppercase;width:60%;margin:0 20%;border:2px solid #FFF;cursor:pointer;}
+#overlay iframe {width:80%;height:600px;margin:100px 10%;border-color:#FFF;border-style:solid;background-color:#FFF;}
+#overlay .close {background-color:#FFF;text-align:right;color:#aaa;font-weight:bold;text-transform:uppercase;width:80%;margin:-100px 10%;border:2px solid #FFF;cursor:pointer;}


### PR DESCRIPTION
To avoid some real noise in indicators we are
applying a outlier-detection technique (1.5xIQR)
and proceeding to normalize them using a pseudo avg
that will fit always within the expected values.

Note we don't apply the outlier algorithm recursively
neither any other detail. Just 1-pass normalization
of noise values.

While 1.5 is a generally accepted value, if we detect
that too much is being normalized, we can always go up
to 2.3 to just normalize "very rare" outliers.

By default, it's disabled, so everything continues
working 100% the same. Only under demand it will become
enabled.

You can enable it by adding n=1 or n=true to the url.

At the same time, a bunch of rounding errors have been
fixed, display is always with 2 decimal digits but all
average calculations are performed with full resolution.

Other small changes are:
- Added support to https.
- Improve red/green and signed display.
- Fix images overlay.