### PR TITLE
Don't hide individual problems when reporting global problems

### DIFF
--- a/webapp/classes/report.php
+++ b/webapp/classes/report.php
@@ -323,8 +323,6 @@ class report {
 
                     list($state, $msg) = $changed;
 
-                    // We unset all the steps to avoid showing too much info with a general increase / decrease is ok.
-                    $this->bigdifferences[$branchnames][$state][$var] = array();
                     $this->bigdifferences[$branchnames][$state][$var]['All steps data combined'] = $msg;
                 }
             }


### PR DESCRIPTION
Sometimes we were getting information like:

dbreads: increment - All steps data combined, 4.49% worse

And then we had to look to details and see which requests were the
failing ones, they may be all, one or more...

With this change we won't be hidding individual problems when
global ones are reported, so it's easier to detect which of the
requests and how much (%) is being affected immediately.