### PR TITLE
Better matcher for memory used scrapping.

### DIFF
--- a/recorder.bsf
+++ b/recorder.bsf
@@ -44,7 +44,7 @@ MoodleResult(JMeterContext ctx) {
     }
 
     String memoryused = "0";
-    Pattern pmemoryused = Pattern.compile(".*?RAM: (\\d+(\\.\\d+)?)MB.*", Pattern.UNIX_LINES | Pattern.DOTALL);
+    Pattern pmemoryused = Pattern.compile(".*?RAM: (\\d+(\\.\\d+)?)[^M]*MB.*", Pattern.UNIX_LINES | Pattern.DOTALL);
     Matcher mmemoryused = pmemoryused.matcher(html);
     if (mmemoryused.matches()) {
         memoryused = mmemoryused.group(1);


### PR DESCRIPTION
Recently (MDL-72643) a change to display_size() was
done and now there is some non-breaking space between
the memory number and the units.

That had caused the performance footer parser to stop working
and memory use was not being reported any more.

With this change, both the old and the new formats are supported
by simply ignoring anything between the digit and the "MB".

Already tested on performance servers, memory reports are back.